### PR TITLE
Added examples for codemeta.json and CITATION.cff files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The group started in May 2017 and will wrap up work in December 2018.
 
 ## Description
 
-This group builds on the previous [Software Citation Working Group](https://www.force11.org/group/software-citation-working-group), 
+This group builds on the previous [Software Citation Working Group](https://www.force11.org/group/software-citation-working-group),
 which developed and publicized an initial set of software citation principles ([https://doi.org/10.7717/peerj-cs.86](https://doi.org/10.7717/peerj-cs.86)).
 
 The activities of the Software Citation Implementation Working Group will be conducted with
@@ -24,7 +24,7 @@ other community forums with related working groups, etc.) to:
 1. endorse the principles
 2. develop sets of guidelines for implementing the principles
 3. help implement the principles
-4. test specific implementations of the principles. 
+4. test specific implementations of the principles.
 
 During this process, the principles may also be updated based on feedback from the activities.
 
@@ -84,7 +84,7 @@ We will use these as milestones in the [GitHub issue tracker](https://github.com
 - [swMATH](http://www.swmath.org)
 - [CIG](https://geodynamics.org)
 - [AAS tutorial on Citing Repositories in AAS Journals (AJ/ApJ)](https://github.com/AASJournals/Tutorials/blob/master/Repositories/CitingRepositories.md)
-- [NITRC (Neuroimaging Informatics Tools and Resources Clearinghouse)](https://www.nitrc.org) 
+- [NITRC (Neuroimaging Informatics Tools and Resources Clearinghouse)](https://www.nitrc.org)
 - [Austrialian National Data Service (ANDS)](https://researchdata.ands.org.au)
 - Australian Software Citation interest group
 - [Zenodo](https://zenodo.org)
@@ -93,7 +93,8 @@ We will use these as milestones in the [GitHub issue tracker](https://github.com
   [Computational Model Library](https://www.openabm.org/models) with versioned releases of agent based models. A new
   version of the Computational Model Library is currently [under development](https://github.com/comses/core.comses.net),
   applying principles from this working group and serving as an example implementation of a citable code archive.
- 
+- [Software Heritage](https://www.softwareheritage.org/)
+
 
 ## Potential early adopter groups
 

--- a/examples/swh-indexer_CITATION.cff
+++ b/examples/swh-indexer_CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.0.0
+message: "Please cite this work with the properties given in this file"
+name: "swh-indexer"
+code-repository: https://forge.softwareheritage.org/diffusion/78/
+programming-language: 
+  - name: Python
+    version: 3.5
+license: https://spdx.org/licenses/GPL-3.0.html
+version: 0.0.35
+authors:
+  - name: Software Heritage
+    email: swh-devel@inria.fr
+    website: https://www.softwareheritage.org
+status: active
+keywords:
+  - indexer
+  - software
+  - mimetype
+  - ctags
+  - language
+  - fossology-license
+  - metadata
+  - metadata-detector
+  - metadata-translator
+references:
+  - type: article
+    title: Software Heritage indexing 4 billions files
+    identifier: my-doi
+date-published: "2016-09-26"
+date-created: "2015-06-12" 
+    

--- a/examples/swh-indexer_codemeta.json
+++ b/examples/swh-indexer_codemeta.json
@@ -1,0 +1,39 @@
+{
+  "@context": "https://raw.githubusercontent.com/codemeta/codemeta/2.0/codemeta.jsonld",
+  "@type": "SoftwareSourceCode",
+  "identifier": "5682a72dc61f86ae69f2841c2184d6159c0b6d5d",
+  "description": "Software Heritage Indexer for revisions and contents",
+  "name": "swh-indexer",
+  "isPartOf": {
+    "@type": "SoftwareSourceCode",
+    "name": "swh-environment",
+    "identifier": "83e766feafde91242883be1bf369ed3e6865824f"
+  },
+  "codeRepository": "https://forge.softwareheritage.org/diffusion/78/",
+  "issueTracker": "https://forge.softwareheritage.org/maniphest/",
+  "license": "https://spdx.org/licenses/GPL-3.0.html",
+  "version": "0.0.35",
+  "author": [
+    {
+      "@type": "Organization",
+      "name": "Software Heritage",
+      "url": "https://www.softwareheritage.org",
+      "email": "swh-devel@inria.fr"
+    },
+  ],
+  "developmentStatus": "active",
+  "keywords": [
+    "indexer",
+    "software",
+    "mimetype",
+    "ctags",
+    "language",
+    "fossology-license",
+    "metadata",
+    "metadata-detector",
+    "metadata-translator"
+  ],
+  "dateCreated":"2016-09-26",
+  "datePublished":"2017-06-12",
+  "programmingLanguage": "Python",
+}


### PR DESCRIPTION
During the FORCE17 SWIG Hackathon we have been working on comparing codemeta.json with @sdruskat's CITATION.cff. 

I have created 2 examples of the swh-indexer (an existing Software Heritage repository) to view the implementation of in repository metadata/citation file.

It can be a basis for discussing the Software Citation Principles from the developer/author point of view
and if the in repository file is enough for citation purposes. 

PS. I also added Software Heritage to the README as a related initiative.  