### PR TITLE
Add CFF to list of related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Guidance for journals:
 ## Related initiatives and projects
 
 - [Codemeta](http://codemeta.github.io/)
+- [Citation File Format](https://citation-file-format.github.io/)
 - [Astrophysics Source Code Library](http://ascl.net/)
 - [SBGrid](https://sbgrid.org)
 - [swMATH](http://www.swmath.org)


### PR DESCRIPTION
This adds a link to the Citation File Format website to the list of related initiatives and projects.